### PR TITLE
Fix missing text when styling is applied

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -283,15 +283,16 @@ impl Screen {
             result.push(title);
         }
 
-        let empty_vec: Vec<&str> = vec![];
         let selector = Selector::parse(r#"p"#).unwrap();
         for element in article.select(&selector) {
-            let content = element.text().collect::<Vec<_>>();
-            if content == empty_vec {
-                continue;
-            }
-            let line = content[0].to_string().trim().to_string();
-            if line == "" {
+            let line = element
+                .text()
+                .collect::<Vec<&str>>()
+                .join("")
+                .trim()
+                .to_string();
+
+            if line.is_empty() {
                 continue;
             }
             result.push(line);


### PR DESCRIPTION
While most stories on freewebnovel are composed of only `p` elements with plain paragraphs, some have `strong` and/or `i` child elements to apply styling. While they are few and far in between, this can result on discarded text and even entire paragraphs.

This contribution is about ensuring that the text contained in them are not lost.